### PR TITLE
Add asdf support

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 22.3
+elixir 1.10.3


### PR DESCRIPTION
This PR allows those who use `asdf` to quickly set up the required Erlang/Elixir version for this module. Both software versions matches the one used in CI.